### PR TITLE
Merge item_type and class to be theme-neutral

### DIFF
--- a/rsc/itemTemplate.html
+++ b/rsc/itemTemplate.html
@@ -1,6 +1,6 @@
-<tr class="$class$ listing-item" onclick="window.location.href='$file-href$'">
-  <td class="$item-type$"></td>
-  <td><a class="$class$ file-name" draggable="true" href="$file-href$">$filename$</a></td>
+<tr class="icon $item-type$ listing-item" onclick="window.location.href='$file-href$'">
+  <td class="icon $item-type$-icon"></td>
+  <td><a class="icon $item-type$ file-name" draggable="true" href="$file-href$">$filename$</a></td>
   <td><small class="text-muted">$last-modified$</small></td>
   <td><small class="file-size text-muted">$filesize$</small></td>
 </tr>

--- a/src/config.toml.example
+++ b/src/config.toml.example
@@ -6,7 +6,6 @@ include_path   = "./rsc/include"
 
 # Change which tags godir will look for. If you're using a pre-made theme, leave these at their defaults.
 tag_contents   = "$content$"
-tag_class      = "$class$"
 tag_file_href  = "$file-href$"
 tag_item_type  = "$item-type$"
 tag_root_step  = "$root-step$"

--- a/src/configManager.go
+++ b/src/configManager.go
@@ -14,7 +14,6 @@ type Config struct {
   Include_path   string
 
   Tag_contents   string
-  Tag_class      string
   Tag_file_href  string
   Tag_item_type  string
   Tag_root_step  string

--- a/src/generate.go
+++ b/src/generate.go
@@ -72,9 +72,8 @@ func GenerateAsync(path string, wg *sync.WaitGroup, semaphore chan struct{}) {
 
   // Add in the "../" item before we generate any real items.
   tmp := opts.ItemTemplate
-  tmp = SubTag(tmp, opts.Conf.Tag_class, "icon dir")
   tmp = SubTag(tmp, opts.Conf.Tag_file_href, "../" + *opts.Args.Filename)
-  tmp = SubTag(tmp, opts.Conf.Tag_item_type, "icon dir-icon")
+  tmp = SubTag(tmp, opts.Conf.Tag_item_type, "dir")
   tmp = SubTag(tmp, opts.Conf.Tag_filename, "Parent Directory")
   tmp = SubTag(tmp, opts.Conf.Tag_last_modified, "-")
   tmp = SubTag(tmp, opts.Conf.Tag_filesize, "-")
@@ -114,8 +113,7 @@ func GenerateAsync(path string, wg *sync.WaitGroup, semaphore chan struct{}) {
 
         // Sub in tags
         tmp = opts.ItemTemplate
-        tmp = SubTag(tmp, opts.Conf.Tag_class, "icon dir")
-        tmp = SubTag(tmp, opts.Conf.Tag_item_type, "icon dir-icon")
+        tmp = SubTag(tmp, opts.Conf.Tag_item_type, "dir")
         tmp = SubTag(tmp, opts.Conf.Tag_filesize, FileSizeCount(DirSize(path + "/" + file.Name())))
         tmp = SubTag(tmp, opts.Conf.Tag_filename, file.Name())
         tmp = SubTag(tmp, opts.Conf.Tag_last_modified, file.ModTime().Format("2006-01-02 15:04:05"))
@@ -172,8 +170,7 @@ func GenerateAsync(path string, wg *sync.WaitGroup, semaphore chan struct{}) {
           console.Log("Regenerating " + path + "/" + file.Name())
           fHash := HashFile(path + "/" + file.Name())
 
-          tmp = SubTag(tmp, opts.Conf.Tag_class, "icon file")
-          tmp = SubTag(tmp, opts.Conf.Tag_item_type, "icon file-icon")
+          tmp = SubTag(tmp, opts.Conf.Tag_item_type, "file")
           tmp = SubTag(tmp, opts.Conf.Tag_filesize, FileSizeCount(file.Size()))
           tmp = SubTag(tmp, opts.Conf.Tag_filename, file.Name())
           tmp = SubTag(tmp, opts.Conf.Tag_last_modified, file.ModTime().Format("2006-01-02 15:04:05"))


### PR DESCRIPTION
This PR removes the `class` property, and strips `item-type` to have just the type in, instead of a class as well. Since we can specify classes in the actual template code itself, it's pointless to have fixed classes in the code when that will limit other theme authors.

The default theme has also been updated with these changes - note you may need to run Godir in force mode for some cached items to update properly.